### PR TITLE
Fix !list and prevent mute evading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -219,3 +219,5 @@ target/*
 /target/
 /.idea/
 ElementumAlterEgo*.iml
+/lib/*
+

--- a/pom.xml
+++ b/pom.xml
@@ -165,7 +165,13 @@
       	<scope>system</scope>
       	<systemPath>${project.basedir}/lib/ElementumBendingPack-2.0.1.jar</systemPath>
     </dependency>
-    
+    <dependency>
+        <groupId>com.elementum.elementumcore</groupId>
+        <artifactId>ElementumCore</artifactId>
+        <version>LATEST</version>
+        <scope>system</scope>
+        <systemPath>${project.basedir}/lib/ElementumCore-2.16.jar</systemPath>
+    </dependency>
   </dependencies>
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/src/com/strangeone101/elementumbot/MessageHandler.java
+++ b/src/com/strangeone101/elementumbot/MessageHandler.java
@@ -1,10 +1,13 @@
 package com.strangeone101.elementumbot;
 
+import java.util.List;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.elementum.elementumcore.chat.chatcontrol.ChatControl;
 import com.strangeone101.elementumbot.elementum.AdvancedBanSupport;
+import me.leoko.advancedban.manager.PunishmentManager;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
@@ -51,6 +54,19 @@ public class MessageHandler {
 		} else if (message.getServerTextChannel().isPresent() && //If the channel doesn't exist (PMs), ignore it
 				message.getServerTextChannel().get().getId() == ConfigManager.getRelayChannel() && message.getAuthor().asUser().get() != api.getYourself()) {
 			if (!message.getContent().startsWith("!") && !message.getContent().startsWith("#")) {
+				if(LinkCommand.isLinked(message.getAuthor().getId())) {
+					UUID uuid = LinkCommand.getUUIDFromID(message.getAuthor().getId());
+					if(PunishmentManager.get().isMuted(uuid.toString().replace("-", ""))) {
+						return; // If the player is muted in game, ignore the message
+					}
+				}
+
+				List<Role> staffRoles = AlterEgoPlugin.SERVER.getRolesByName("Staff");
+				if(!ChatControl.chatEnabled &&
+						(staffRoles.size() < 1 || !staffRoles.get(0).hasUser(message.getAuthor().asUser().get()))) {
+					return; // If the chat is muted and the player isn't staff, ignore the message
+				}
+
 				String displayName = StringUtil.emojiTranslate(message.getAuthor().getDisplayName() == null ? message.getAuthor().getName() : message.getAuthor().getDisplayName()).trim();
 
 				String roleDisplay = ChatColor.DARK_GRAY + "No Role"; //If they have no role, this is the default text that shows

--- a/src/com/strangeone101/elementumbot/command/ListCommand.java
+++ b/src/com/strangeone101/elementumbot/command/ListCommand.java
@@ -31,7 +31,8 @@ public class ListCommand extends CommandRunnable {
 		
 		if (players.equals("")) players = "None";
 		else players = players.substring(2);
-		Future<Message> msg = command.reply("Currently online (" + players.split(",").length + "): " + players);
+		Future<Message> msg = command.reply("Currently online ("
+				+ (players.equals("None") ? 0 : players.split(",").length) + "): " + players);
 		CleanupHandler.cleanup(command.getOriginal(), 1000L * 60 * 5);
 		
 		new BukkitRunnable() {


### PR DESCRIPTION
* Fix !list saying that there is 1 player when there is none
* Prevent users from using relay when
-> they're muted
-> the chat is muted and they're not staff